### PR TITLE
Refactor customization step and fix Ubuntu runner issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
   customize:
     name: Customize image
     needs: download
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
@@ -100,7 +100,8 @@ jobs:
       - name: Rebuild image
         run: |
           sudo virt-customize -a "${{ env.SOURCE_IMGFILE }}" \
-            --run "customize-${{ matrix.variant }}.sh" \
+            --run-command "apt-get --yes update" \
+            --run-command "apt-get --yes install qemu-guest-agent" \
             --run-command "apt-get --yes autoremove" \
             --run-command "apt-get --yes clean autoclean" \
             --run-command "rm -rf /var/lib/apt/lists/*" \

--- a/customize-qemu.sh
+++ b/customize-qemu.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-# Install packages
-apt-get --yes update
-apt-get --yes install qemu-guest-agent


### PR DESCRIPTION
**Changes:**

- **Inlined qemu-guest-agent installation:** Removed the external customize script to simplify the build process.
- **Fixed CI runner environment:** Switched runs-on from ubuntu-latest to ubuntu-22.04 for the customization step.

**Note on the CI environment change:**

We have switched the runs-on property from ubuntu-latest to ubuntu-22.04 for the customization step.

**Reasoning:**

The current ubuntu-latest image (which points to Ubuntu 24.04 Noble Numbat) introduces stricter AppArmor profiles and unprivileged user namespace restrictions. These changes frequently cause libguestfs to fail when launching its backend appliance, resulting in "Permission Denied" errors or kernel crashes during the virtualization step.

Since libguestfs-tools relies on nested execution via QEMU, using ubuntu-22.04 provides a more stable and compatible environment for these disk manipulation tasks. This is a documented workaround within the GitHub Actions community for workflows involving virt-customize or similar tools.